### PR TITLE
[cassandra] Adding timeout flag and vendoring dependencies for SDK

### DIFF
--- a/integrations/cassandra/src/cassandra.go
+++ b/integrations/cassandra/src/cassandra.go
@@ -17,6 +17,7 @@ type argumentList struct {
 	Username   string `default:"" help:"Username for accessing JMX."`
 	Password   string `default:"" help:"Password for the given user."`
 	ConfigPath string `default:"/etc/cassandra.yaml" help:"Cassandra configuration file."`
+	Timeout    int    `default:"2000" help:"Timeout in milliseconds per single JMX query."`
 }
 
 const (

--- a/integrations/cassandra/src/metrics.go
+++ b/integrations/cassandra/src/metrics.go
@@ -32,7 +32,7 @@ func getMetrics() (map[string]interface{}, map[string]map[string]interface{}, er
 	}
 
 	for _, query := range jmxPatterns {
-		results, err := jmx.Query(query)
+		results, err := jmx.Query(query, args.Timeout)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/vendor/github.com/newrelic/infra-integrations-sdk/args/args.go
+++ b/vendor/github.com/newrelic/infra-integrations-sdk/args/args.go
@@ -11,8 +11,8 @@ import (
 )
 
 // DefaultArgumentList includes the minimal set of necessary arguments for an
-// integration. You can embed this struct in your struct of arguments to include
-// them automatically.
+// integration. To include them automatically, embed this struct in your struct
+// of arguments.
 type DefaultArgumentList struct {
 	Verbose   bool `default:"false" help:"Print more information to logs."`
 	Pretty    bool `default:"false" help:"Print pretty formatted JSON."`
@@ -46,7 +46,7 @@ func underscore(s string) string {
 	return strings.ToLower(strings.Join(a, "_"))
 }
 
-// SetupArgs parses a struct's definition and populates the arguments out of the
+// SetupArgs parses a struct's definition and populates the arguments from the
 // fields it defines. Each of the fields in the struct can define their defaults
 // and help string by using tags:
 //

--- a/vendor/github.com/newrelic/infra-integrations-sdk/args/json.go
+++ b/vendor/github.com/newrelic/infra-integrations-sdk/args/json.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 )
 
-// JSON type, to be used from the arguments structs
+// JSON type, to be used from the arguments structs.
 // This argument type will parse a serialized JSON string into a map which
 type JSON struct {
 	value interface{}

--- a/vendor/github.com/newrelic/infra-integrations-sdk/cache/cache.go
+++ b/vendor/github.com/newrelic/infra-integrations-sdk/cache/cache.go
@@ -21,7 +21,7 @@ func SetNow(newNow func() time.Time) {
 
 const cacheTTL = 1 * time.Minute
 
-// Cache is a map-like structure that is initialized and stored into a JSON
+// Cache is a map-like structure that is initialized and stored in a JSON
 // file. It also saves the timestamp when a key was stored.
 type Cache struct {
 	path       string
@@ -30,8 +30,8 @@ type Cache struct {
 }
 
 // NewCache will create and initialize a DiskCache object. It expects the
-// NRIA_CACHE_PATH environment variable to point to the file with the cache,
-// in case it is not set, it will act as a memory-only cache.
+// NRIA_CACHE_PATH environment variable to point to the file with the cache. If
+// it is not set, this will act as a memory-only cache.
 func NewCache() (*Cache, error) {
 	cache := &Cache{
 		Data:       make(map[string]interface{}, 0),
@@ -77,6 +77,7 @@ func NewCache() (*Cache, error) {
 }
 
 // Save marshalls and stores the data a Cache is holding into disk as a JSON
+// file.
 func (cache *Cache) Save() error {
 	if cache.path == "" {
 		return nil
@@ -95,9 +96,9 @@ func (cache *Cache) Save() error {
 	return nil
 }
 
-// Get looks for a key in the cache adn returns its value together with the timestamp
-// of when it was last set. The third boolean return value indicates whether the
-// key has been found or not.
+// Get looks for a key in the cache and returns its value together with the
+// timestamp of when it was last set. The third returned value indicates whether
+// the key has been found or not.
 func (cache *Cache) Get(name string) (float64, int64, bool) {
 	val, ok := cache.Data[name]
 	if ok {
@@ -109,7 +110,7 @@ func (cache *Cache) Get(name string) (float64, int64, bool) {
 	return 0, 0, false
 }
 
-// Set adds a value into the cache and it also stores the current timestamp
+// Set adds a value into the cache and it also stores the current timestamp.
 func (cache *Cache) Set(name string, value float64) int64 {
 	cache.Data[name] = value
 	cache.Timestamps[name] = now().Unix()

--- a/vendor/github.com/newrelic/infra-integrations-sdk/cache/global.go
+++ b/vendor/github.com/newrelic/infra-integrations-sdk/cache/global.go
@@ -2,24 +2,24 @@ package cache
 
 var instance, err = NewCache()
 
-// Save marshalls and stores the data the cache is holding into disk as a JSON
+// Save marshalls and stores the data the cache is holding into disk as a JSON file.
 func Save() error {
 	return instance.Save()
 }
 
 // Get looks for a key in the cache and returns its value together with the timestamp
-// of when it was last set. The third boolean return value indicates whether the
-// key has been found or not.
+// of when it was last set. The third returned value indicates whether
+// the key has been found or not.
 func Get(name string) (float64, int64, bool) {
 	return instance.Get(name)
 }
 
-// Set adds a value into the cache together with the current timestamp
+// Set adds a value into the cache together with the current timestamp.
 func Set(name string, value float64) int64 {
 	return instance.Set(name, value)
 }
 
-// Status will return an error if any was found during global Cache creation
+// Status will return an error if any was found during global Cache creation.
 func Status() error {
 	return err
 }

--- a/vendor/github.com/newrelic/infra-integrations-sdk/jmx/jmx.go
+++ b/vendor/github.com/newrelic/infra-integrations-sdk/jmx/jmx.go
@@ -1,3 +1,7 @@
+/*
+Package jmx is a library to get metrics through JMX. It requires additional
+setup. Read https://github.com/newrelic/infra-integrations-sdk#jmx-support for
+instructions. */
 package jmx
 
 import (
@@ -23,8 +27,7 @@ var done sync.WaitGroup
 var jmxCommand = "/usr/bin/nrjmx"
 
 const (
-	outTimeout    time.Duration = 1000 * time.Millisecond
-	jmxLineBuffer               = 4 * 1024 * 1024 // Max 4MB per line. If single lines are outputting more JSON than that, we likely need smaller-scoped JMX queries
+	jmxLineBuffer = 4 * 1024 * 1024 // Max 4MB per line. If single lines are outputting more JSON than that, we likely need smaller-scoped JMX queries
 )
 
 func getCommand(hostname, port, username, password string) []string {
@@ -36,10 +39,10 @@ func getCommand(hostname, port, username, password string) []string {
 		cliCommand = []string{jmxCommand}
 	}
 
-	cliCommand = append(
-		cliCommand, "--hostname", hostname, "--port", port,
-		"--username", username, "--password", password,
-	)
+	cliCommand = append(cliCommand, "--hostname", hostname, "--port", port)
+	if username != "" && password != "" {
+		cliCommand = append(cliCommand, "--username", username, "--password", password)
+	}
 
 	return cliCommand
 }
@@ -119,12 +122,13 @@ func doQuery(out chan []byte, errorChan chan error, queryString []byte) {
 	}
 }
 
-// Query returns a map with the attribute names and its values from the nrjmx tool
-func Query(objectPattern string) (map[string]interface{}, error) {
+// Query executes JMX query against nrjmx tool waiting up to timeout (in milliseconds)
+// and returns a map with the result.
+func Query(objectPattern string, timeout int) (map[string]interface{}, error) {
 	result := make(map[string]interface{})
 	pipe := make(chan []byte)
 	queryErrors := make(chan error)
-
+	outTimeout := time.Duration(timeout) * time.Millisecond
 	// Send the query async to the underlying process so we can timeout it
 	go doQuery(pipe, queryErrors, []byte(fmt.Sprintf("%s\n", objectPattern)))
 

--- a/vendor/github.com/newrelic/infra-integrations-sdk/log/log.go
+++ b/vendor/github.com/newrelic/infra-integrations-sdk/log/log.go
@@ -6,7 +6,7 @@ import (
 	"github.com/Sirupsen/logrus"
 )
 
-// SetupLogging redirect logs to stderr and configures the log level.
+// SetupLogging redirects logs to stderr and configures the log level.
 func SetupLogging(verbose bool) {
 	logrus.SetOutput(os.Stderr)
 	if verbose {

--- a/vendor/github.com/newrelic/infra-integrations-sdk/metric/metrics.go
+++ b/vendor/github.com/newrelic/infra-integrations-sdk/metric/metrics.go
@@ -7,24 +7,26 @@ import (
 	"github.com/newrelic/infra-integrations-sdk/cache"
 )
 
-// SourceType defines the kind of data source and how we are going to treat it
+// SourceType defines the kind of data source. Based on this SourceType, metric
+// package performs some calculations with it. Check below the description for
+// each one.
 type SourceType int
 
 const (
 	// GAUGE is a value that may increase and decrease. It is stored as-is.
 	GAUGE SourceType = iota
-	// RATE is an ever-growing value which might be reseted. We store the change rate.
+	// RATE is an ever-growing value which might be reseted. The package calculates the change rate.
 	RATE SourceType = iota
-	// DELTA is an ever-growing value which might be reseted. We store the differences between samples.
+	// DELTA is an ever-growing value which might be reseted. The package calculates the difference between samples.
 	DELTA SourceType = iota
 	// ATTRIBUTE is any string value
 	ATTRIBUTE SourceType = iota
 )
 
-// MetricSet is the basic structure for storing metrics
+// MetricSet is the basic structure for storing metrics.
 type MetricSet map[string]interface{}
 
-// NewMetricSet returns a new MetricSet instance
+// NewMetricSet returns a new MetricSet instance.
 func NewMetricSet(eventType string) MetricSet {
 	ms := MetricSet{}
 	ms.SetMetric("event_type", eventType, ATTRIBUTE)
@@ -32,7 +34,8 @@ func NewMetricSet(eventType string) MetricSet {
 }
 
 // SetMetric adds a metric to the MetricSet object or updates the metric value
-// if the metric already exists, sampling if sourceType requires it.
+// if the metric already exists, performing a calculation if the SourceType
+// (RATE, DELTA) requires it.
 func (ms MetricSet) SetMetric(name string, value interface{}, sourceType SourceType) error {
 	var err error
 	var newValue = value

--- a/vendor/github.com/newrelic/infra-integrations-sdk/sdk/data.go
+++ b/vendor/github.com/newrelic/infra-integrations-sdk/sdk/data.go
@@ -13,10 +13,10 @@ import (
 type inventoryItem map[string]interface{}
 
 // Inventory is the data type for inventory data produced by an integration data
-// source and emitted to the agent's inventory data store
+// source and emitted to the agent's inventory data store.
 type Inventory map[string]inventoryItem
 
-// SetItem stores a value into the inventory data structure
+// SetItem stores a value into the inventory data structure.
 func (i Inventory) SetItem(key string, field string, value interface{}) {
 	if _, ok := i[key]; ok {
 		i[key][field] = value
@@ -26,10 +26,12 @@ func (i Inventory) SetItem(key string, field string, value interface{}) {
 
 }
 
-// Event is the data type for single shot events
+// Event is the data type to represent arbitrary, one-off messages for key
+// activities on a system.
 type Event map[string]interface{}
 
-// Integration defines the format of the output JSON that plugins will return
+// Integration defines the format of the output JSON that integrations will
+// return.
 type Integration struct {
 	Name               string              `json:"name"`
 	ProtocolVersion    string              `json:"protocol_version"`
@@ -40,7 +42,7 @@ type Integration struct {
 	prettyOutput       bool
 }
 
-// NewIntegration initializes a new instance of integration data
+// NewIntegration initializes a new instance of integration data.
 func NewIntegration(name string, version string, arguments interface{}) (*Integration, error) {
 	err := args.SetupArgs(arguments)
 	if err != nil {
@@ -68,15 +70,18 @@ func NewIntegration(name string, version string, arguments interface{}) (*Integr
 	return integration, nil
 }
 
-// NewMetricSet returns a new instance of MetricSet with its sample attached to the IntegrationData
+// NewMetricSet returns a new instance of MetricSet with its sample attached to
+// the IntegrationData.
 func (integration *Integration) NewMetricSet(eventType string) *metric.MetricSet {
 	ms := metric.NewMetricSet(eventType)
 	integration.Metrics = append(integration.Metrics, &ms)
 	return &ms
 }
 
-// Publish will run any tasks before publishing the data. In this case, it will
-// store the cache and print the JSON repreentation of the integration to stdout
+// Publish runs all necessary tasks before publishing the data. Currently, it
+// stores the cache, prints the JSON representation of the integration to stdout
+// and re-initializes the integration object (allowing re-use it during the
+// execution of your code).
 func (integration *Integration) Publish() error {
 	if err := cache.Save(); err != nil {
 		return err

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -23,52 +23,52 @@
 			"versionExact": "v1.3"
 		},
 		{
-			"checksumSHA1": "jyYVyZKBHiXT9Fecb7iRUyXWwdI=",
+			"checksumSHA1": "MfMZSsn79Ey3/+Zn2UX1mgVGU/A=",
 			"path": "github.com/newrelic/infra-integrations-sdk/args",
-			"revision": "b31bc81a228f7cb48496dd6c87815a119df35907",
-			"revisionTime": "2017-07-20T13:55:07Z",
-			"version": "v1.0.0",
-			"versionExact": "v1.0.0"
+			"revision": "8e5c9f0622e44eea3ec32a34a0ebd14a89b28cc7",
+			"revisionTime": "2017-09-18T10:40:03Z",
+			"version": "master",
+			"versionExact": "master"
 		},
 		{
-			"checksumSHA1": "4t7HNYy4VZjvfFY6PsrzU8g1hJQ=",
+			"checksumSHA1": "45zcAovsGwfEvjiql/9SI1JWArE=",
 			"path": "github.com/newrelic/infra-integrations-sdk/cache",
-			"revision": "b31bc81a228f7cb48496dd6c87815a119df35907",
-			"revisionTime": "2017-07-20T13:55:07Z",
-			"version": "v1.0.0",
-			"versionExact": "v1.0.0"
+			"revision": "8e5c9f0622e44eea3ec32a34a0ebd14a89b28cc7",
+			"revisionTime": "2017-09-18T10:40:03Z",
+			"version": "master",
+			"versionExact": "master"
 		},
 		{
-			"checksumSHA1": "r/tqLGJ4GhpuI3iPJTSc3jXeQ28=",
+			"checksumSHA1": "0EEXgZ9Fn+YXKhVEcRUI/4bydmQ=",
 			"path": "github.com/newrelic/infra-integrations-sdk/jmx",
-			"revision": "b31bc81a228f7cb48496dd6c87815a119df35907",
-			"revisionTime": "2017-07-20T13:55:07Z",
-			"version": "v1.0.0",
-			"versionExact": "v1.0.0"
+			"revision": "8e5c9f0622e44eea3ec32a34a0ebd14a89b28cc7",
+			"revisionTime": "2017-09-18T10:40:03Z",
+			"version": "master",
+			"versionExact": "master"
 		},
 		{
-			"checksumSHA1": "6eFl1VzgBKkUbpcOdVhSqLz2oD4=",
+			"checksumSHA1": "gRz6v46pNwphQXmd9rSP05I7cHo=",
 			"path": "github.com/newrelic/infra-integrations-sdk/log",
-			"revision": "b31bc81a228f7cb48496dd6c87815a119df35907",
-			"revisionTime": "2017-07-20T13:55:07Z",
-			"version": "v1.0.0",
-			"versionExact": "v1.0.0"
+			"revision": "8e5c9f0622e44eea3ec32a34a0ebd14a89b28cc7",
+			"revisionTime": "2017-09-18T10:40:03Z",
+			"version": "master",
+			"versionExact": "master"
 		},
 		{
-			"checksumSHA1": "v6d2OtRT+Xxb8Ytv3L7RzWU9cHI=",
+			"checksumSHA1": "/OBil2T0jjmaRvLhTCsMXLVG2N4=",
 			"path": "github.com/newrelic/infra-integrations-sdk/metric",
-			"revision": "b31bc81a228f7cb48496dd6c87815a119df35907",
-			"revisionTime": "2017-07-20T13:55:07Z",
-			"version": "v1.0.0",
-			"versionExact": "v1.0.0"
+			"revision": "8e5c9f0622e44eea3ec32a34a0ebd14a89b28cc7",
+			"revisionTime": "2017-09-18T10:40:03Z",
+			"version": "master",
+			"versionExact": "master"
 		},
 		{
-			"checksumSHA1": "QAOEN0X+lEiWTXI7LjOWj1u+yfs=",
+			"checksumSHA1": "VorxNshE8dikg0M7bOHfUTzupfI=",
 			"path": "github.com/newrelic/infra-integrations-sdk/sdk",
-			"revision": "b31bc81a228f7cb48496dd6c87815a119df35907",
-			"revisionTime": "2017-07-20T13:55:07Z",
-			"version": "v1.0.0",
-			"versionExact": "v1.0.0"
+			"revision": "8e5c9f0622e44eea3ec32a34a0ebd14a89b28cc7",
+			"revisionTime": "2017-09-18T10:40:03Z",
+			"version": "master",
+			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "Dbw6GrXllNPecT0AnoOyAiv66EI=",


### PR DESCRIPTION
#### Description of the changes

In some cases JMX queries takes more time than 1s (which was originally set), the timeout flag was added, so a user can configure it, depending on Cassandra performance and also default value was increased to 2s.

Note: For the moment we are fetching the dependencies for the infra-integration-sdk from the master. Once we generate the SDK release we will update the vendor folder with it.

#### PR Review Checklist
### Author

- [x] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
