### PR TITLE
Improving slave metrics to not log Warn message when not needed

### DIFF
--- a/integrations/mysql/src/metrics-parse.go
+++ b/integrations/mysql/src/metrics-parse.go
@@ -68,8 +68,17 @@ func populateInventory(inventory sdk.Inventory, rawData map[string]interface{}) 
 }
 
 func populateMetrics(sample *metric.MetricSet, rawMetrics map[string]interface{}) {
+	if rawMetrics["node_type"] == "master" {
+		delete(defaultMetrics, "cluster.slaveRunning")
+	}
 	populatePartialMetrics(sample, rawMetrics, defaultMetrics)
+
 	if args.ExtendedMetrics {
+		if rawMetrics["node_type"] == "slave" {
+			for key := range slaveMetrics {
+				extendedMetrics[key] = slaveMetrics[key]
+			}
+		}
 		populatePartialMetrics(sample, rawMetrics, extendedMetrics)
 	}
 	if args.ExtendedInnodbMetrics {

--- a/integrations/mysql/src/metrics.go
+++ b/integrations/mysql/src/metrics.go
@@ -117,18 +117,6 @@ var extendedMetrics = map[string][]interface{}{
 	"db.threadsCached":                     {"Threads_cached", metric.GAUGE},
 	"db.threadsCreatedPerSecond":           {"Threads_created", metric.RATE},
 	"db.threadCacheMissRate":               {threadCacheMissRate, metric.GAUGE},
-	"db.relayLogSpace":                     {"Relay_Log_Space", metric.GAUGE},
-	"cluster.secondsBehindMaster":          {"Seconds_Behind_Master", metric.GAUGE},
-	"cluster.slaveIORunning":               {"Slave_IO_Running", metric.ATTRIBUTE},
-	"cluster.slaveSQLRunning":              {"Slave_SQL_Running", metric.ATTRIBUTE},
-	"cluster.lastIOErrno":                  {"Last_IO_Errno", metric.GAUGE},
-	"cluster.lastIOError":                  {"Last_IO_Error", metric.ATTRIBUTE},
-	"cluster.lastSQLErrno":                 {"Last_SQL_Errno", metric.GAUGE},
-	"cluster.lastSQLError":                 {"Last_SQL_Error", metric.ATTRIBUTE},
-	"cluster.masterLogFile":                {"Master_Log_File", metric.ATTRIBUTE},
-	"cluster.readMasterLogPos":             {"Read_Master_Log_Pos", metric.GAUGE},
-	"cluster.relayMasterLogFile":           {"Relay_Master_Log_File", metric.ATTRIBUTE},
-	"cluster.execMasterLogPos":             {"Exec_Master_Log_Pos", metric.GAUGE},
 }
 
 func threadCacheMissRate(metrics map[string]interface{}) (float64, bool) {
@@ -142,6 +130,21 @@ func threadCacheMissRate(metrics map[string]interface{}) (float64, bool) {
 		return float64(threadsCreated) / float64(connections), true
 	}
 	return 0, false
+}
+
+var slaveMetrics = map[string][]interface{}{
+	"cluster.secondsBehindMaster": {"Seconds_Behind_Master", metric.GAUGE},
+	"cluster.slaveIORunning":      {"Slave_IO_Running", metric.ATTRIBUTE},
+	"cluster.slaveSQLRunning":     {"Slave_SQL_Running", metric.ATTRIBUTE},
+	"cluster.lastIOErrno":         {"Last_IO_Errno", metric.GAUGE},
+	"cluster.lastIOError":         {"Last_IO_Error", metric.ATTRIBUTE},
+	"cluster.lastSQLErrno":        {"Last_SQL_Errno", metric.GAUGE},
+	"cluster.lastSQLError":        {"Last_SQL_Error", metric.ATTRIBUTE},
+	"cluster.masterLogFile":       {"Master_Log_File", metric.ATTRIBUTE},
+	"cluster.readMasterLogPos":    {"Read_Master_Log_Pos", metric.GAUGE},
+	"cluster.relayMasterLogFile":  {"Relay_Master_Log_File", metric.ATTRIBUTE},
+	"cluster.execMasterLogPos":    {"Exec_Master_Log_Pos", metric.GAUGE},
+	"db.relayLogSpace":            {"Relay_Log_Space", metric.GAUGE},
 }
 
 var innodbMetrics = map[string][]interface{}{


### PR DESCRIPTION
#### Description of the changes
Recently there were added new metrics for slave cluster. But when the integration was executed on Master cluster then we were logging the warning message about missing metrics. This was not correct, because these slave specific metrics are only required on slave cluster.

#### PR Review Checklist
### Author

- [x] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer

### Reviewer

- [x] review code for readability
- [x] verify that high risk behavior changes are well tested
- [x] check license for any new external dependency
- [x] ask questions about anything that isn't clear and obvious
- [x] approve the PR when you consider it's good to merge
