### PR TITLE
[cassandra] Setting Cassandra Column Families Limit as configurable 

### DIFF
--- a/integrations/cassandra/src/cassandra.go
+++ b/integrations/cassandra/src/cassandra.go
@@ -12,12 +12,13 @@ import (
 type argumentList struct {
 	sdk_args.DefaultArgumentList
 
-	Hostname   string `default:"localhost" help:"Hostname or IP where Cassandra is running."`
-	Port       int    `default:"7199" help:"Port on which JMX server is listening."`
-	Username   string `default:"" help:"Username for accessing JMX."`
-	Password   string `default:"" help:"Password for the given user."`
-	ConfigPath string `default:"/etc/cassandra.yaml" help:"Cassandra configuration file."`
-	Timeout    int    `default:"2000" help:"Timeout in milliseconds per single JMX query."`
+	Hostname            string `default:"localhost" help:"Hostname or IP where Cassandra is running."`
+	Port                int    `default:"7199" help:"Port on which JMX server is listening."`
+	Username            string `default:"" help:"Username for accessing JMX."`
+	Password            string `default:"" help:"Password for the given user."`
+	ConfigPath          string `default:"/etc/cassandra.yaml" help:"Cassandra configuration file."`
+	Timeout             int    `default:"2000" help:"Timeout in milliseconds per single JMX query."`
+	ColumnFamiliesLimit int    `default:"20" help:"Limit on number of Cassandra Column Families."`
 }
 
 const (

--- a/integrations/cassandra/src/metrics.go
+++ b/integrations/cassandra/src/metrics.go
@@ -8,8 +8,6 @@ import (
 	"github.com/newrelic/infra-integrations-sdk/metric"
 )
 
-const columnFamiliesLimit = 20
-
 // getMetrics will gather all node and keyspace level metrics and return them as two maps
 // The main metrics map will contain all the keys got from JMX and the keyspace metrics map
 // Will contain maps for each <keyspace>.<columnFamily> found while inspecting JMX metrics.
@@ -51,7 +49,7 @@ func getMetrics() (map[string]interface{}, map[string]map[string]interface{}, er
 				if !found {
 					_, found := visitedColumnFamilies[eventkey]
 					if !found {
-						if len(visitedColumnFamilies) < columnFamiliesLimit {
+						if len(visitedColumnFamilies) < args.ColumnFamiliesLimit {
 							visitedColumnFamilies[eventkey] = struct{}{}
 						} else {
 							continue


### PR DESCRIPTION
#### Description of the changes
As hard-coded value for Cassandra Column Families was to low for some users, we decided to set it as configurable parameter.


#### PR Review Checklist
### Author

- [x] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer

### Reviewer

- [x] review code for readability
- [x] verify that high risk behavior changes are well tested
- [x] check license for any new external dependency
- [x] ask questions about anything that isn't clear and obvious
- [x] approve the PR when you consider it's good to merge
