### PR TITLE
[mysql] Do not show slave_running metric when replication privileges …

### DIFF
--- a/integrations/mysql/src/metrics-parse.go
+++ b/integrations/mysql/src/metrics-parse.go
@@ -68,7 +68,7 @@ func populateInventory(inventory sdk.Inventory, rawData map[string]interface{}) 
 }
 
 func populateMetrics(sample *metric.MetricSet, rawMetrics map[string]interface{}) {
-	if rawMetrics["node_type"] == "master" {
+	if rawMetrics["node_type"] != "slave" {
 		delete(defaultMetrics, "cluster.slaveRunning")
 	}
 	populatePartialMetrics(sample, rawMetrics, defaultMetrics)

--- a/integrations/mysql/src/metrics.go
+++ b/integrations/mysql/src/metrics.go
@@ -47,7 +47,8 @@ var defaultMetrics = map[string][]interface{}{
 	"software.edition":                            {"version_comment", metric.ATTRIBUTE},
 	"software.version":                            {"version", metric.ATTRIBUTE},
 	"cluster.nodeType":                            {"node_type", metric.ATTRIBUTE},
-	"cluster.slaveRunning":                        {slaveRunningAsNumber, metric.GAUGE},
+	// If a cluster instance is not a slave, then the metric cluster.slaveRunning will be removed.
+	"cluster.slaveRunning": {slaveRunningAsNumber, metric.GAUGE},
 }
 
 func qCacheUtilization(metrics map[string]interface{}) (float64, bool) {


### PR DESCRIPTION
…not granted

#### Description of the changes

Very small change, but... when replication privileges are not granted we log Warn messages:
```
WARN[0000] Can't get node type, not enough privileges (must grant REPLICATION CLIENT)
WARN[0000] Can't find raw metrics in results for cluster.nodeType
```
and with the previous implementation we were populating metric `cluster.slaveRunning`. But IMO we shouldn't as we are not able to identify `cluster.nodeType`

#### PR Review Checklist
### Author

- [x] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer

### Reviewer

- [x] review code for readability
- [x] verify that high risk behavior changes are well tested
- [x] check license for any new external dependency
- [x] ask questions about anything that isn't clear and obvious
- [x] approve the PR when you consider it's good to merge
