### PR TITLE
Allow Apache integration specify the server's trusted CA

### DIFF
--- a/integrations/apache/CHANGELOG.md
+++ b/integrations/apache/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.1.0 (2018-02-08)
+### Added
+- Allow working with own's Apache Certificate Authority through the `ca_cert_file` and `ca_cert_dir` configuration
+  options.
+
 ## 1.0.0 (2017-11-29)
 ### Added
 - Initial release, which contains inventory and metrics data

--- a/integrations/apache/CHANGELOG.md
+++ b/integrations/apache/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## 1.1.0 (2018-02-08)
 ### Added
-- Allow working with own's Apache Certificate Authority through the `ca_cert_file` and `ca_cert_dir` configuration
+- Allow working with own's Apache Certificate Authority through the `ca_bundle_file` and `ca_bundle_dir` configuration
   options.
 
 ## 1.0.0 (2017-11-29)

--- a/integrations/apache/README.md
+++ b/integrations/apache/README.md
@@ -27,15 +27,15 @@ http://127.0.0.1/server-status?auto
 You can change this URL by modifying the `status_url` instance parameter of your `apache-config.yml` file.
 
 If the `/server-status` is reachable only though an HTTPS connection which uses a certificate that is signed by your own
-Certificate Authority (e.g. for internal use or development purposes), you will need to make sure one of the next actions
-have been taken:
+Certificate Authority (e.g. for internal use or development purposes), you will need to make sure **one** of the next alternative
+actions have been taken:
 
-* Install your Certificate Authority in your host. The Apache integration will look for it by default in the host's root
+* *Option 1*: Install your Certificate Authority in your host. The Apache integration will look for it by default in the host's root
   bundle for Certificate Authorities.
-* Update the `apache-config.yml` to have at leastone of the next instance parameters configured: `ca_bundle_file` or
+* *Option 2*: Update the `apache-config.yml` to have at least one of the next instance parameters configured: `ca_bundle_file` or
   `ca_bundle_dir`, whose values must be, respectively, the absolute paths to your alternative Certificate Authorities' bundle
-  file (or the directory where they are).
-* Add to the [Infrastructure Agent configuration file](https://docs.newrelic.com/docs/infrastructure/new-relic-infrastructure/configuration/configure-infrastructure-agent))
+  file (or the directory where they are). 
+* *Option 3*: Add to the [Infrastructure Agent configuration file](https://docs.newrelic.com/docs/infrastructure/new-relic-infrastructure/configuration/configure-infrastructure-agent))
   the `ca_bundle_file` or `ca_bundle_dir` property (which are analogue to the properties explained in the previous
   bullet), and then passthrough them to the integrations by adding: `passthrough_environment: CA_BUNDLE_FILE` or
   `passthrough_environment: CA_BUNDLE_DIR` to the `infra-agent.yml` configuration file. 

--- a/integrations/apache/README.md
+++ b/integrations/apache/README.md
@@ -5,7 +5,7 @@ metrics and inventory reported by Apache web server.
 
 Inventory data is obtained using `httpd` command in RedHat family distributions
 and `apache2ctl` command in Debian family distributions.
-Metrics data is obtained doing HTTP requests to `/status` endpoint, provided by
+Metrics data is obtained doing HTTP requests to `/server-status` endpoint, provided by
 `mod_status` Apache module.
 
 ## Usage
@@ -18,6 +18,27 @@ In order to use the Apache Integration it is required to configure
 `apache-config.yml.sample` file. Firstly, rename the file to
 `apache-config.yml`. Then, depending on your needs, specify all instances that
 you want to monitor with correct arguments.
+
+The integration assumes your `/server-status` is reachable though the next URL:
+```
+http://127.0.0.1/server-status?auto
+```
+
+You can change this URL by modifying the `status_url` instance parameter of your `apache-config.yml` file.
+
+If the `/server-status` is reachable only though an HTTPS connection which uses a certificate that is signed by your own
+Certificate Authority (e.g. for internal use or development purposes), you will need to make sure one of the next actions
+have been taken:
+
+* Install your Certificate Authority in your host. The Apache integration will look for it by default in the host's root
+  bundle for Certificate Authorities.
+* Update the `apache-config.yml` to have at leastone of the next instance parameters configured: `ca_bundle_file` or
+  `ca_bundle_dir`, whose values must be, respectively, the absolute paths to your alternative Certificate Authorities' bundle
+  file (or the directory where they are).
+* Add to the [Infrastructure Agent configuration file](https://docs.newrelic.com/docs/infrastructure/new-relic-infrastructure/configuration/configure-infrastructure-agent))
+  the `ca_bundle_file` or `ca_bundle_dir` property (which are analogue to the properties explained in the previous
+  bullet), and then passthrough them to the integrations by adding: `passthrough_environment: CA_BUNDLE_FILE` or
+  `passthrough_environment: CA_BUNDLE_DIR` to the `infra-agent.yml` configuration file. 
 
 ## Integration development usage
 

--- a/integrations/apache/apache-config.yml.sample
+++ b/integrations/apache/apache-config.yml.sample
@@ -5,6 +5,7 @@ instances:
       command: metrics
       arguments:
           status_url: http://127.0.0.1/server-status?auto
+          ca_cert_dir: /etc/ssl/certs
       labels:
           env: production
           role: load_balancer

--- a/integrations/apache/apache-config.yml.sample
+++ b/integrations/apache/apache-config.yml.sample
@@ -5,7 +5,6 @@ instances:
       command: metrics
       arguments:
           status_url: http://127.0.0.1/server-status?auto
-          ca_cert_dir: /etc/ssl/certs
       labels:
           env: production
           role: load_balancer

--- a/integrations/apache/src/apache.go
+++ b/integrations/apache/src/apache.go
@@ -11,8 +11,8 @@ import (
 type argumentList struct {
 	sdk_args.DefaultArgumentList
 	StatusURL    string `default:"http://127.0.0.1/server-status?auto" help:"Apache status-server URL."`
-	CABundleFile string `default:"" help:"Alternative Certificate Authority bundle file"`
-	CABundleDir  string `default:"" help:"Alternative Certificate Authority bundle directory"`
+	CABundleFile string `help:"Alternative Certificate Authority bundle file"`
+	CABundleDir  string `help:"Alternative Certificate Authority bundle directory"`
 }
 
 const (

--- a/integrations/apache/src/apache.go
+++ b/integrations/apache/src/apache.go
@@ -10,9 +10,9 @@ import (
 
 type argumentList struct {
 	sdk_args.DefaultArgumentList
-	StatusURL  string `default:"http://127.0.0.1/server-status?auto" help:"Apache status-server URL."`
-	CACertFile string `default:"" help:"Apache server alternative Certificate Authority certificate file"`
-	CACertDir  string `default:"" help:"Apache server alternative Certificate Authority certificate directory"`
+	StatusURL    string `default:"http://127.0.0.1/server-status?auto" help:"Apache status-server URL."`
+	CABundleFile string `default:"" help:"Alternative Certificate Authority bundle file"`
+	CABundleDir  string `default:"" help:"Alternative Certificate Authority bundle directory"`
 }
 
 const (
@@ -40,9 +40,9 @@ func main() {
 		log.Debug("Fetching data for '%s' integration", integrationName+"-metrics")
 		ms := integration.NewMetricSet("ApacheSample")
 		provider := &Status{
-			CACertDir:   args.CACertDir,
-			CACertFile:  args.CACertFile,
-			HTTPTimeout: defaultHTTPTimeout,
+			CABundleDir:  args.CABundleDir,
+			CABundleFile: args.CABundleFile,
+			HTTPTimeout:  defaultHTTPTimeout,
 		}
 		fatalIfErr(getMetricsData(provider, ms))
 	}

--- a/integrations/apache/src/apache.go
+++ b/integrations/apache/src/apache.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"time"
+
 	sdk_args "github.com/newrelic/infra-integrations-sdk/args"
 	"github.com/newrelic/infra-integrations-sdk/log"
 	"github.com/newrelic/infra-integrations-sdk/sdk"
@@ -8,12 +10,16 @@ import (
 
 type argumentList struct {
 	sdk_args.DefaultArgumentList
-	StatusURL string `default:"http://127.0.0.1/server-status?auto" help:"Apache status-server URL."`
+	StatusURL  string `default:"http://127.0.0.1/server-status?auto" help:"Apache status-server URL."`
+	CACertFile string `default:"" help:"Apache server alternative Certificate Authority certificate file"`
+	CACertDir  string `default:"" help:"Apache server alternative Certificate Authority certificate directory"`
 }
 
 const (
 	integrationName    = "com.newrelic.apache"
-	integrationVersion = "1.0.0"
+	integrationVersion = "1.1.0"
+
+	defaultHTTPTimeout = time.Second * 1
 )
 
 var args argumentList
@@ -33,7 +39,12 @@ func main() {
 	if args.All || args.Metrics {
 		log.Debug("Fetching data for '%s' integration", integrationName+"-metrics")
 		ms := integration.NewMetricSet("ApacheSample")
-		fatalIfErr(getMetricsData(ms))
+		provider := &Status{
+			CACertDir:   args.CACertDir,
+			CACertFile:  args.CACertFile,
+			HTTPTimeout: defaultHTTPTimeout,
+		}
+		fatalIfErr(getMetricsData(provider, ms))
 	}
 
 	fatalIfErr(integration.Publish())

--- a/integrations/apache/src/metrics.go
+++ b/integrations/apache/src/metrics.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/newrelic/infra-integrations-sdk/log"
 	"github.com/newrelic/infra-integrations-sdk/metric"
@@ -150,11 +149,9 @@ func getRawMetrics(reader *bufio.Reader) (map[string]interface{}, error) {
 	return metrics, nil
 }
 
-func getMetricsData(sample *metric.MetricSet) error {
-	// TODO: externalize client instantiation so we can mock it for accurate unit testing
-	netClient := &http.Client{
-		Timeout: time.Second * 1,
-	}
+func getMetricsData(status *Status, sample *metric.MetricSet) error {
+	netClient := status.NewClient()
+
 	log.Debug("retrieving Apache Status from %s", args.StatusURL)
 	resp, err := netClient.Get(args.StatusURL)
 	if err != nil {

--- a/integrations/apache/src/status.go
+++ b/integrations/apache/src/status.go
@@ -11,12 +11,12 @@ import (
 
 // Status will create new HTTP clients based on its configuration
 type Status struct {
-	CACertFile  string
-	CACertDir   string
-	HTTPTimeout time.Duration
+	CABundleFile string
+	CABundleDir  string
+	HTTPTimeout  time.Duration
 }
 
 // NewClient creates a new http.Client based on the provider's configuration
 func (p Status) NewClient() *http.Client {
-	return svccommon_http_client.GetHttpClient(p.CACertFile, p.CACertDir, p.HTTPTimeout)
+	return svccommon_http_client.GetHttpClient(p.CABundleFile, p.CABundleDir, p.HTTPTimeout)
 }

--- a/integrations/apache/src/status.go
+++ b/integrations/apache/src/status.go
@@ -1,0 +1,22 @@
+// Package status encapsulates the instantiation and configuration of the Apache status client
+package main
+
+import (
+	"net/http"
+
+	"time"
+
+	"go.datanerd.us/p/meatballs/backend/shared/svccommon/http/client"
+)
+
+// Status will create new HTTP clients based on its configuration
+type Status struct {
+	CACertFile  string
+	CACertDir   string
+	HTTPTimeout time.Duration
+}
+
+// NewClient creates a new http.Client based on the provider's configuration
+func (p Status) NewClient() *http.Client {
+	return svccommon_http_client.GetHttpClient(p.CACertFile, p.CACertDir, p.HTTPTimeout)
+}

--- a/vendor/go.datanerd.us/p/meatballs/backend/shared/svccommon/http/client/http_client.go
+++ b/vendor/go.datanerd.us/p/meatballs/backend/shared/svccommon/http/client/http_client.go
@@ -1,0 +1,70 @@
+package svccommon_http_client
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"io/ioutil"
+	"log"
+	"net"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func GetHttpClient(certFile string, certDirectory string, httpTimeout time.Duration) *http.Client {
+	// go default http transport settings
+	transport := &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		DialContext:           (&net.Dialer{Timeout: 30 * time.Second, KeepAlive: 30 * time.Second}).DialContext,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+
+	if certFile != "" || certDirectory != "" {
+		transport.TLSClientConfig = &tls.Config{RootCAs: getCertPool(certFile, certDirectory)}
+	}
+
+	return &http.Client{
+		Timeout:   httpTimeout * time.Second,
+		Transport: transport,
+	}
+}
+
+func getCertPool(certFile string, certDirectory string) *x509.CertPool {
+	caCertPool := x509.NewCertPool()
+	if certFile != "" {
+		caCert, err := ioutil.ReadFile(certFile)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		ok := caCertPool.AppendCertsFromPEM(caCert)
+		if !ok {
+			log.Print("Cert could not be appended")
+		}
+	}
+	if certDirectory != "" {
+		files, err := ioutil.ReadDir(certDirectory)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		for _, f := range files {
+			if strings.Contains(f.Name(), ".pem") {
+				caCertFilePath := filepath.Join(certDirectory + "/" + f.Name())
+				caCert, err := ioutil.ReadFile(caCertFilePath)
+				if err != nil {
+					log.Fatal(err)
+				}
+				ok := caCertPool.AppendCertsFromPEM(caCert)
+				if !ok {
+					log.Print("Cert could not be appended")
+				}
+			}
+		}
+	}
+	return caCertPool
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -87,6 +87,12 @@
 			"versionExact": "v2.0.0"
 		},
 		{
+			"checksumSHA1": "UKc8Cy7ubIr49WkrZXasS94V75I=",
+			"path": "go.datanerd.us/p/meatballs/backend/shared/svccommon/http/client",
+			"revision": "62a731dbb2617715ec218bfc85a76beecfc716bb",
+			"revisionTime": "2018-01-20T00:25:19Z"
+		},
+		{
 			"checksumSHA1": "Dbw6GrXllNPecT0AnoOyAiv66EI=",
 			"path": "golang.org/x/sys/unix",
 			"revision": "9c9d83fe39ed3fd2d9249fcf6b755891fff54b03",


### PR DESCRIPTION
#### Description of the changes

Usually the host should be configured so it trusts its own Apache
Certificate Authority, even if it is self-created and not trusted
outside the host.

In case the user don't want to do it, two configuration options have
been provided to allow the user to specify the CA certificate or
the folder where the certificate is.

#### PR Review Checklist
### Author

- [x] add a risk label after carefully considering the "blast radius" of your changes
- [ ] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
