### PR TITLE
Fix --replaces format for deb packages

### DIFF
--- a/Makefile-package.mk
+++ b/Makefile-package.mk
@@ -12,9 +12,9 @@ PACKAGER           = "New Relic Infrastructure Team <infrastructure-eng@newrelic
 PACKAGE_URL        = "https://www.newrelic.com/infrastructure"
 SUMMARY            = "New Relic Infrastructure Integrations"
 DESCRIPTION        = "New Relic Infrastructure Integrations extend the core New Relic\nInfrastructure agent's capabilities to allow you to collect metric and\nlive state data from your infrastructure components such as MySQL,\nNGINX and Cassandra."
-FPM_COMMON_OPTIONS = --verbose -C $(SOURCE_DIR) -s dir -n $(PROJECT_NAME) -v $(VERSION) --iteration $(RELEASE) --prefix "" --license $(LICENSE) --vendor $(VENDOR) -m $(PACKAGER) --url $(PACKAGE_URL) --config-files /etc/newrelic-infra/ --description "$$(printf $(DESCRIPTION))" --depends "newrelic-infra >= 1.0.726" --depends "nrjmx" --replaces "newrelic-infra-integrations-beta <= 1.0.0"
-FPM_DEB_OPTIONS    = -t deb -p $(PACKAGES_DIR)/deb/
-FPM_RPM_OPTIONS    = -t rpm -p $(PACKAGES_DIR)/rpm/ --epoch 0 --rpm-summary $(SUMMARY)
+FPM_COMMON_OPTIONS = --verbose -C $(SOURCE_DIR) -s dir -n $(PROJECT_NAME) -v $(VERSION) --iteration $(RELEASE) --prefix "" --license $(LICENSE) --vendor $(VENDOR) -m $(PACKAGER) --url $(PACKAGE_URL) --config-files /etc/newrelic-infra/ --description "$$(printf $(DESCRIPTION))" --depends "newrelic-infra >= 1.0.726" --depends "nrjmx"
+FPM_DEB_OPTIONS    = -t deb -p $(PACKAGES_DIR)/deb/ --replaces "newrelic-infra-integrations-beta (<= 1.0.0)"
+FPM_RPM_OPTIONS    = -t rpm -p $(PACKAGES_DIR)/rpm/ --epoch 0 --rpm-summary $(SUMMARY) --replaces "newrelic-infra-integrations-beta <= 1.0.0"
 
 package: create-bins prep-pkg-env $(PACKAGE_TYPES)
 


### PR DESCRIPTION
#### Description of the changes

deb `Replaces` format `{package} ({comparator} {version})`.
We were setting it without **parenthesis**, which caused errors during `apt-update`.

This should be considered as a hotfix.

#### PR Review Checklist
### Author

- [x] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
