### PR TITLE
Fix Redis config sample

### DIFF
--- a/integrations/redis/redis-config.yml.sample
+++ b/integrations/redis/redis-config.yml.sample
@@ -6,7 +6,7 @@ instances:
     arguments:
       hostname: localhost
       port: 6379
-      keys: {"0":["<KEY_1>"],"1":["<KEY_2>"]}
+      keys: '{"0":["<KEY_1>"],"1":["<KEY_2>"]}'
 
   - name: redis-inventory
     command: inventory


### PR DESCRIPTION
#### Description of the changes

The documentation and sample YAML for Redis key reads is wrong. The sample without quotes does not initialize plugin at all

#### PR Review Checklist
### Author

- [ ] add a risk label after carefully considering the "blast radius" of your changes
- [ ] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [ ] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
